### PR TITLE
remove album icon

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" type="text/css" href="./fonts/fonts.css" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
     <link rel="manifest" href="./manifest.json">
-    <link rel="shortcut icon" href="./favicon.ico">
+    <link rel="" href="./favicon.ico">
 
     <title>Spotify React App</title>
 

--- a/src/App.css
+++ b/src/App.css
@@ -52,10 +52,11 @@ body {
 .left-side-section {
   position: fixed;
   top: 10px;
-  left: 10px;
+  /* left: 10px; */
   bottom: 10px;
   width: 180px;
   overflow-y: auto;
+  background-color: black;
 }
 
 .main-section {

--- a/src/components/ArtWork/component.js
+++ b/src/components/ArtWork/component.js
@@ -3,8 +3,17 @@ import PropTypes from 'prop-types';
 import './ArtWork.css';
 
 const ArtWork = (albumArtwork) => (
-  <div className='album-artwork-container'>
-    <img alt="artwork" className='album-artwork' src={albumArtwork.albumImage} />
+  <div className="album-artwork-container">
+    {albumArtwork.albumImage ? (
+      <img
+        alt="artwork"
+        className="album-artwork"
+        src={albumArtwork.albumImage}
+      />
+    ) : (
+      //basically display nothing
+      <h1></h1>
+    )}
   </div>
 );
 


### PR DESCRIPTION
Sorry for my previous pull request. 
I am newbie.

This time: 

- I removed the album icon if no albums is selected.
- changed background color of side menu to black to make it look more like spotify original
- favicon is now spotify logo